### PR TITLE
Fix ticker freq. This is applied for 429zi, as it has /2 system clock.

### DIFF
--- a/source/hal_tick.c
+++ b/source/hal_tick.c
@@ -78,7 +78,11 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    if (SystemCoreClock == 16000000) {
+        TimMasterHandle.Init.Prescaler     = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    } else {
+        TimMasterHandle.Init.Prescaler     = (uint32_t)(SystemCoreClock / 2 / 1000000) - 1; // 1 µs tick
+    }
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;


### PR DESCRIPTION
This might not be true for any F4 mcu, something which we should fix -
hal tick init per platform.

Ticker, ticker_2 - passes

@bremoran 
