### PR TITLE
Module - stm32f439zi module fix dep name

### DIFF
--- a/module.json
+++ b/module.json
@@ -30,7 +30,7 @@
       "cmsis-core-stm32f429xi": "^1.0.0"
     },
     "stm32f439zi": {
-      "cmsis-core-stm32f429xi": "^1.0.0"
+      "cmsis-core-stm32f439zi": "~0.1.0"
     }
   }
 }


### PR DESCRIPTION
cmsis-core-stm32f439zi module is currently not v1.x.x, we will have to verify it's up to date to the cmsis-core v1 and release new major version

Don't merge yet please

@niklas-arm 