### PR TITLE
Choose target dependency only for legacy targets.

### DIFF
--- a/module.json
+++ b/module.json
@@ -23,13 +23,13 @@
     "mbed-hal-st-stm32f4": ">=1.0.4"
   },
   "targetDependencies": {
-    "stm32f401xe": {
+    "stm32f401xe-no-inherit": {
       "cmsis-core-stm32f401xe": "~0.1.0"
     },
-    "stm32f429xi": {
+    "stm32f429xi-no-inherit": {
       "cmsis-core-stm32f429xi": "^1.0.0"
     },
-    "stm32f439zi": {
+    "stm32f439zi-no-inherit": {
       "cmsis-core-stm32f439zi": "~0.1.0"
     }
   }


### PR DESCRIPTION
Analog to https://github.com/ARMmbed/mbed-hal-st-stm32f4/pull/34.

This change is dependent on:
- https://github.com/ARMmbed/target-st-nucleo-f401re-gcc/pull/8
- https://github.com/ARMmbed/target-st-stm32f429i-disco/pull/27

@bogdanm @0xc0170 @bremoran @mjs-arm @autopulated 