### PR TITLE
Add stm32f407 target dependency

### DIFF
--- a/module.json
+++ b/module.json
@@ -26,6 +26,9 @@
     "stm32f401xe-no-inherit": {
       "cmsis-core-stm32f401xe": "~0.1.0"
     },
+    "stm32f407xg": {
+      "cmsis-core-stm32f407xg": "~0.0.1"
+    },
     "stm32f429xi-no-inherit": {
       "cmsis-core-stm32f429xi": "^1.0.0"
     },


### PR DESCRIPTION
This change in the dependencies is necessary to support stm32f407.
The patch adds stm32f407xx.h header file to the include path as well, otherwise the yotta build will stop with an error.
