### PR TITLE
Updated dependency on latest uvisor-lib

### DIFF
--- a/module.json
+++ b/module.json
@@ -18,7 +18,7 @@
     "cmsis-core-stm32f4"
   ],
   "dependencies": {
-    "uvisor-lib": "^1.0.0",
+    "uvisor-lib": ">=1.0.0,<3.0.0",
     "cmsis-core": "*",
     "mbed-hal-st-stm32f4": ">=1.0.4"
   },


### PR DESCRIPTION
uvisor-lib 2.0.0 was just released. This commit updates the dependency
on uvisor-lib to take into account this version.

@0xc0170 @bogdanm 